### PR TITLE
Fix build-pricing caching by using go-version instead of go-version-file

### DIFF
--- a/.github/workflows/build-pricing.yml
+++ b/.github/workflows/build-pricing.yml
@@ -28,9 +28,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: 'gcosts/go.mod'
-          cache-dependency-path: |
-            'build/go.sum'
-            'gcosts/go.sum'
+          cache-dependency-path: '**/go.sum'
 
       # Compile build/skus CLI
       - name: 🍳 Build build/skus

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,9 +29,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: 'gcosts/go.mod'
-          cache-dependency-path: |
-            'build/go.sum'
-            'gcosts/go.sum'
+          cache-dependency-path: '**/go.sum'
 
       # https://github.com/marketplace/actions/run-golangci-lint
       - name: 🌡️ Lint build


### PR DESCRIPTION
First off, thanks for taking the time to contribute!

## Please Complete the Following

- [ ] I read `CONTRIBUTING.md`
- [ ] I used tabs to indent
- [ ] I have tested my change

## Notes

Feel free to put whatever you want here.
